### PR TITLE
Fix path handling for file:// URLs in stages on Windows

### DIFF
--- a/tests/e2e/test_data_pipeline_merge_workflow.py
+++ b/tests/e2e/test_data_pipeline_merge_workflow.py
@@ -110,7 +110,7 @@ class TestDataPipelineMergeWorkflow:
         # Create external stage pointing to temp directory
         stage_sql = f"""
         CREATE STAGE customer_data_stage
-        URL = 'file://{temp_files_dir}'
+        URL = 'file://{temp_files_dir.as_posix()}'
         FILE_FORMAT = csv_customer_format
         """
 

--- a/tests/integration/test_enhanced_csv_copy_into.py
+++ b/tests/integration/test_enhanced_csv_copy_into.py
@@ -3,6 +3,7 @@
 import csv
 import os
 import tempfile
+from pathlib import Path
 
 import duckdb
 
@@ -22,7 +23,7 @@ class TestEnhancedCSVCopyInto:
         self.translator = CopyIntoTranslator(self.stage_manager, self.format_manager)
 
         # Create a temporary directory for test files
-        self.temp_dir = tempfile.mkdtemp()
+        self.temp_dir = Path(tempfile.mkdtemp())
 
     def teardown_method(self):
         """Clean up test fixtures."""
@@ -59,7 +60,7 @@ class TestEnhancedCSVCopyInto:
             f.write("2|Bob|bob@test.com\n")
 
         # Create stage pointing to temp directory
-        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir}")
+        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir.as_posix()}")
 
         # Create table
         self.conn.execute("CREATE TABLE test_table (id INT, name VARCHAR, email VARCHAR)")
@@ -89,7 +90,7 @@ class TestEnhancedCSVCopyInto:
             f.write(b"id,name\r\n1,Alice\r\n2,Bob\r\n")
 
         # Create stage
-        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir}")
+        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir.as_posix()}")
 
         # Create table
         self.conn.execute("CREATE TABLE test_table (id INT, name VARCHAR)")
@@ -116,7 +117,7 @@ class TestEnhancedCSVCopyInto:
         self._create_test_csv("test.csv", test_data)
 
         # Create stage
-        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir}")
+        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir.as_posix()}")
 
         # Create table
         self.conn.execute("CREATE TABLE test_table (id INT, name VARCHAR)")
@@ -144,7 +145,7 @@ class TestEnhancedCSVCopyInto:
         self._create_test_csv("utf8.csv", test_data, encoding="utf-8")
 
         # Create stage
-        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir}")
+        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir.as_posix()}")
 
         # Create table
         self.conn.execute("CREATE TABLE test_table (id INT, name VARCHAR)")
@@ -177,7 +178,7 @@ class TestEnhancedCSVCopyInto:
             f.write("4,N/A,david@test.com\n")  # N/A string (not first)
 
         # Create stage
-        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir}")
+        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir.as_posix()}")
 
         # Create table
         self.conn.execute("CREATE TABLE test_table (id INT, name VARCHAR, email VARCHAR)")
@@ -211,7 +212,7 @@ class TestEnhancedCSVCopyInto:
             f.write("3\n")  # Missing column
 
         # Create stage
-        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir}")
+        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir.as_posix()}")
 
         # Create table
         self.conn.execute("CREATE TABLE test_table (id INT, name VARCHAR)")
@@ -239,7 +240,7 @@ class TestEnhancedCSVCopyInto:
             f.write(b'3|"Charlie"|"charlie@test.com"\r\n')
 
         # Create stage
-        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir}")
+        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir.as_posix()}")
 
         # Create table
         self.conn.execute("CREATE TABLE test_table (id INT, name VARCHAR, email VARCHAR)")
@@ -281,7 +282,7 @@ class TestEnhancedCSVCopyInto:
         self._create_test_csv("simple.csv", test_data)
 
         # Create stage
-        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir}")
+        self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{self.temp_dir.as_posix()}")
 
         # Create table
         self.conn.execute("CREATE TABLE test_table (id INT, name VARCHAR)")

--- a/tests/integration/test_parquet_copy_into_real.py
+++ b/tests/integration/test_parquet_copy_into_real.py
@@ -40,7 +40,7 @@ class TestParquetCopyIntoReal:
             shutil.copy2(source_file, dest_file)
 
             # Create stage pointing to temp directory using EXTERNAL type for file:// URLs
-            self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{tmpdir}")
+            self.stage_manager.create_stage("test_stage", stage_type="EXTERNAL", url=f"file://{Path(tmpdir).as_posix()}")
 
             # Create target table with correct schema
             self.conn.execute("""
@@ -90,7 +90,7 @@ class TestParquetCopyIntoReal:
                 shutil.copy2(source_file, dest_file)
 
                 # Create stage
-                self.stage_manager.create_stage(f"stage_{compression}", stage_type="EXTERNAL", url=f"file://{tmpdir}")
+                self.stage_manager.create_stage(f"stage_{compression}", stage_type="EXTERNAL", url=f"file://{Path(tmpdir).as_posix()}")
 
                 # Create target table (drop if exists from previous iteration)
                 self.conn.execute(f"DROP TABLE IF EXISTS employees_{compression}")
@@ -135,7 +135,7 @@ class TestParquetCopyIntoReal:
             shutil.copy2(source_file, dest_file)
 
             # Create stage
-            self.stage_manager.create_stage("null_stage", stage_type="EXTERNAL", url=f"file://{tmpdir}")
+            self.stage_manager.create_stage("null_stage", stage_type="EXTERNAL", url=f"file://{Path(tmpdir).as_posix()}")
 
             # Create target table
             self.conn.execute("""
@@ -177,7 +177,7 @@ class TestParquetCopyIntoReal:
             shutil.copy2(source_file, dest_file)
 
             # Create stage
-            self.stage_manager.create_stage("binary_stage", stage_type="EXTERNAL", url=f"file://{tmpdir}")
+            self.stage_manager.create_stage("binary_stage", stage_type="EXTERNAL", url=f"file://{Path(tmpdir).as_posix()}")
 
             # Create target table
             self.conn.execute("""
@@ -221,7 +221,7 @@ class TestParquetCopyIntoReal:
             shutil.copy2(source_file, dest_file)
 
             # Create stage
-            self.stage_manager.create_stage("inline_stage", stage_type="EXTERNAL", url=f"file://{tmpdir}")
+            self.stage_manager.create_stage("inline_stage", stage_type="EXTERNAL", url=f"file://{Path(tmpdir).as_posix()}")
 
             # Create target table
             self.conn.execute("""
@@ -262,7 +262,7 @@ class TestParquetCopyIntoReal:
             shutil.copy2(source_file, dest_file)
 
             # Create stage
-            self.stage_manager.create_stage("unsupported_stage", stage_type="EXTERNAL", url=f"file://{tmpdir}")
+            self.stage_manager.create_stage("unsupported_stage", stage_type="EXTERNAL", url=f"file://{Path(tmpdir).as_posix()}")
 
             # Create target table
             self.conn.execute("""
@@ -311,7 +311,7 @@ class TestParquetCopyIntoReal:
             shutil.copy2(source_file, dest_file)
 
             # Create stage
-            self.stage_manager.create_stage("lzo_stage", stage_type="EXTERNAL", url=f"file://{tmpdir}")
+            self.stage_manager.create_stage("lzo_stage", stage_type="EXTERNAL", url=f"file://{Path(tmpdir).as_posix()}")
 
             # Create target table
             self.conn.execute("""
@@ -355,7 +355,7 @@ class TestParquetCopyIntoReal:
             shutil.copy2(source_file, dest_file)
 
             # Create stage
-            self.stage_manager.create_stage("auto_stage", stage_type="EXTERNAL", url=f"file://{tmpdir}")
+            self.stage_manager.create_stage("auto_stage", stage_type="EXTERNAL", url=f"file://{Path(tmpdir).as_posix()}")
 
             # Create target table
             self.conn.execute("""

--- a/tests/unit/snowflake/test_ingestion.py
+++ b/tests/unit/snowflake/test_ingestion.py
@@ -1,5 +1,6 @@
 """Tests for Mockhaus data ingestion functionality."""
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -66,7 +67,7 @@ class TestDataIngestion(unittest.TestCase):
 
     def test_create_external_stage_with_url(self) -> None:
         """Test creating an EXTERNAL stage with URL."""
-        file_url = f"file://{self.test_data_dir}"
+        file_url = f"file://{self.test_data_dir.as_posix()}"
         sql = f"CREATE STAGE test_external_stage URL = '{file_url}'"
 
         result = self.executor.execute_snowflake_sql(sql)
@@ -95,7 +96,8 @@ class TestDataIngestion(unittest.TestCase):
         assert stage.stage_type == "EXTERNAL"
         assert stage.url == s3_url
         # Should create local path under external/s3/
-        assert "external/s3/my-bucket/data" in stage.local_path
+        expected_path = os.path.join("external", "s3", "my-bucket", "data")
+        assert expected_path in stage.local_path
 
     def test_drop_stage(self) -> None:
         """Test dropping a stage."""
@@ -176,7 +178,7 @@ class TestDataIngestion(unittest.TestCase):
         assert result.success
 
         # Create stage pointing to test data
-        file_url = f"file://{self.test_data_dir}"
+        file_url = f"file://{self.test_data_dir.as_posix()}"
         stage_sql = f"CREATE STAGE test_data_stage URL = '{file_url}'"
         result = self.executor.execute_snowflake_sql(stage_sql)
         assert result.success
@@ -218,7 +220,7 @@ class TestDataIngestion(unittest.TestCase):
         assert result.success
 
         # Create stage pointing to test data
-        file_url = f"file://{self.test_data_dir}"
+        file_url = f"file://{self.test_data_dir.as_posix()}"
         stage_sql = f"CREATE STAGE test_data_stage2 URL = '{file_url}'"
         result = self.executor.execute_snowflake_sql(stage_sql)
         assert result.success
@@ -277,7 +279,7 @@ class TestDataIngestion(unittest.TestCase):
         assert result.success
 
         # Create stage
-        file_url = f"file://{self.test_data_dir}"
+        file_url = f"file://{self.test_data_dir.as_posix()}"
         stage_sql = f"CREATE STAGE test_error_stage URL = '{file_url}'"
         result = self.executor.execute_snowflake_sql(stage_sql)
         assert result.success
@@ -303,7 +305,7 @@ class TestDataIngestion(unittest.TestCase):
         assert result.success
 
         # Create stage
-        file_url = f"file://{self.test_data_dir}"
+        file_url = f"file://{self.test_data_dir.as_posix()}"
         stage_sql = f"CREATE STAGE test_error_stage2 URL = '{file_url}'"
         result = self.executor.execute_snowflake_sql(stage_sql)
         assert result.success
@@ -423,7 +425,7 @@ class TestDataIngestion(unittest.TestCase):
         stage_manager = self.stage_manager
 
         # Test valid stage reference (directory exists)
-        file_url = f"file://{self.test_data_dir}"
+        file_url = f"file://{self.test_data_dir.as_posix()}"
         stage_manager.create_stage("valid_stage", "EXTERNAL", file_url)
         assert stage_manager.validate_stage_access("@valid_stage/")
 
@@ -449,7 +451,7 @@ class TestDataIngestion(unittest.TestCase):
         assert result.success
 
         # Create stage
-        file_url = f"file://{self.test_data_dir}"
+        file_url = f"file://{self.test_data_dir.as_posix()}"
         stage_sql = f"CREATE STAGE complex_stage URL = '{file_url}'"
         result = self.executor.execute_snowflake_sql(stage_sql)
         assert result.success


### PR DESCRIPTION
A significant number of tests across the e2e, integration, and unit test suites were failing specifically on Windows environments. The root cause was identified as incorrect handling of file paths for file:// URLs used in CREATE STAGE commands.