### PR TITLE
Create Pydantic models for Snowflake API Proxy

### DIFF
--- a/src/mockhaus/server/snowflake_api/models.py
+++ b/src/mockhaus/server/snowflake_api/models.py
@@ -1,0 +1,142 @@
+"""
+This module defines the Pydantic models used for data validation and serialization
+in the context of interacting with the Snowflake SQL REST API. These models represent
+the structured data for requests and responses, ensuring that all communication
+with the API is type-safe and conforms to the expected format.
+
+The models cover various aspects of the API, including:
+- Statement submission and status tracking.
+- Result set metadata and data handling.
+- Column and partition information.
+- Error reporting.
+- Cancellation requests.
+
+Each class corresponds to a specific JSON object structure defined in the
+Snowflake API documentation, using Pydantic's features for validation,
+serialization, and handling of optional fields and aliases.
+"""
+from pydantic import BaseModel, Field
+from typing import Optional, List, Dict, Any
+from enum import Enum
+
+class StatementStatus(str, Enum):
+    """Enumeration for the status of a Snowflake statement.
+    
+    Attributes:
+        SUBMITTED: The statement has been received and is pending execution.
+        RUNNING: The statement is currently executing.
+        SUCCEEDED: The statement executed successfully.
+        FAILED: The statement failed to execute.
+        CANCELED: The statement was canceled by the user.
+    """
+    SUBMITTED = "SUBMITTED"
+    RUNNING = "RUNNING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    CANCELED = "CANCELED"
+
+class RowType(BaseModel):
+    """Describes a column in the result set.
+    
+    Attributes:
+        name: The name of the column.
+        database: The database the column belongs to.
+        schema_: The schema the column belongs to.
+        table: The table the column belongs to.
+        scale: The scale of the number for numeric types.
+        precision: The precision of the number for numeric types.
+        length: The length of the data for string/text types.
+        type: The Snowflake data type (e.g., "fixed", "text", "boolean").
+        nullable: Whether the column can contain null values.
+        byte_length: The byte length of the data for binary or text types.
+        collation: The collation specification for string types.
+    """
+    name: str
+    database: str
+    schema_: str = Field(..., alias="schema")
+    table: str
+    scale: Optional[int] = None
+    precision: Optional[int] = None
+    length: Optional[int] = None
+    type: str
+    nullable: bool
+    byte_length: Optional[int] = Field(None, alias="byteLength")
+    collation: Optional[str] = None
+
+class PartitionInfo(BaseModel):
+    """Provides information about a data partition.
+    
+    Attributes:
+        row_count: The number of rows in the partition.
+        uncompressed_size: The uncompressed size of the partition in bytes.
+        compressed_size: The compressed size of the partition in bytes.
+    """
+    row_count: int = Field(..., alias="rowCount")
+    uncompressed_size: int = Field(..., alias="uncompressedSize")
+    compressed_size: int = Field(..., alias="compressedSize")
+
+class ResultSetMetadata(BaseModel):
+    """Provides metadata about the result set.
+    
+    Attributes:
+        num_rows: The total number of rows in the result set.
+        format: The format of the data returned (e.g., "jsonv2").
+        row_type: A list of RowType objects, one for each column.
+        partition_info: A list of PartitionInfo objects, one for each partition.
+    """
+    num_rows: int = Field(..., alias="numRows")
+    format: str
+    row_type: List[RowType] = Field(..., alias="rowType")
+    partition_info: List[PartitionInfo] = Field(..., alias="partitionInfo")
+
+class StatementRequest(BaseModel):
+    """Request to submit a new SQL statement for execution.
+    
+    Attributes:
+        statement: The SQL statement to execute.
+        timeout: The number of seconds to wait for the statement to complete.
+        database: The database to use for the statement.
+        schema_: The schema to use for the statement.
+        warehouse: The warehouse to use for the statement.
+        role: The role to use for the statement.
+    """
+    statement: str
+    timeout: Optional[int] = None
+    database: Optional[str] = None
+    schema_: Optional[str] = Field(None, alias="schema")
+    warehouse: Optional[str] = None
+    role: Optional[str] = None
+
+class StatementResponse(BaseModel):
+    """Response containing the status and results of a statement.
+    
+    Attributes:
+        statement_handle: A unique identifier for the statement.
+        status: The current status of the statement.
+        sql_state: The SQLSTATE code for the statement.
+        date_time: The timestamp of the response.
+        message: A message associated with the response.
+        error_code: The error code, if the statement failed.
+        error_message: The error message, if the statement failed.
+        result_set_meta_data: Metadata about the result set.
+        result_set: The result set data.
+    """
+    statement_handle: str = Field(..., alias="statementHandle")
+    status: StatementStatus
+    sql_state: str = Field(..., alias="sqlState")
+    date_time: str = Field(..., alias="dateTime")
+    message: Optional[str] = None
+    error_code: Optional[str] = Field(None, alias="errorCode")
+    error_message: Optional[str] = Field(None, alias="errorMessage")
+    result_set_meta_data: Optional[ResultSetMetadata] = Field(None, alias="resultSetMetaData")
+    result_set: Optional[List[Dict[str, Any]]] = Field(None, alias="resultSet")
+
+class CancellationResponse(BaseModel):
+    """Response to a statement cancellation request.
+    
+    Attributes:
+        status: The status of the cancellation request.
+        message: A message associated with the cancellation.
+    """
+    status: str
+    message: str

--- a/tests/unit/server/snowflake_api/test_models.py
+++ b/tests/unit/server/snowflake_api/test_models.py
@@ -1,0 +1,129 @@
+"""
+This module contains unit tests for the Pydantic models defined in
+`src.mockhaus.server.snowflake_api.models`. These tests ensure that each model
+correctly validates incoming data, handles required and optional fields,
+and correctly maps field aliases.
+
+The tests cover:
+- Successful instantiation of models with valid data.
+- Validation errors for missing required fields or incorrect data types.
+- Correct assignment of values, especially for fields with aliases.
+- Enum membership checks.
+"""
+
+import pytest
+from pydantic import ValidationError
+from src.mockhaus.server.snowflake_api.models import (
+    StatementStatus,
+    RowType,
+    PartitionInfo,
+    ResultSetMetadata,
+    StatementRequest,
+    StatementResponse,
+    CancellationResponse,
+)
+
+def test_statement_status_enum():
+    """Tests that the StatementStatus enum members have the correct string values."""
+    assert StatementStatus.SUBMITTED == "SUBMITTED"
+    assert StatementStatus.RUNNING == "RUNNING"
+    assert StatementStatus.SUCCEEDED == "SUCCEEDED"
+    assert StatementStatus.FAILED == "FAILED"
+    assert StatementStatus.CANCELED == "CANCELED"
+
+class TestRowType:
+    """Tests for the RowType model."""
+    def test_row_type_success(self):
+        """Tests successful creation of a RowType model with valid data."""
+        data = {
+            "name": "col1",
+            "database": "db1",
+            "schema": "schema1",
+            "table": "table1",
+            "type": "text",
+            "nullable": False,
+        }
+        model = RowType(**data)
+        assert model.name == "col1"
+        assert model.schema_ == "schema1"
+
+    def test_row_type_missing_required(self):
+        """Tests that a ValidationError is raised when required fields are missing."""
+        with pytest.raises(ValidationError):
+            RowType(name="col1")
+
+class TestPartitionInfo:
+    """Tests for the PartitionInfo model."""
+    def test_partition_info_success(self):
+        """Tests successful creation of a PartitionInfo model with valid data."""
+        data = {"rowCount": 10, "uncompressedSize": 100, "compressedSize": 50}
+        model = PartitionInfo(**data)
+        assert model.row_count == 10
+        assert model.uncompressed_size == 100
+        assert model.compressed_size == 50
+
+    def test_partition_info_invalid_type(self):
+        """Tests that a ValidationError is raised for invalid data types."""
+        with pytest.raises(ValidationError):
+            PartitionInfo(rowCount="abc", uncompressedSize=100, compressedSize=50)
+
+class TestResultSetMetadata:
+    """Tests for the ResultSetMetadata model."""
+    def test_result_set_metadata_success(self):
+        """Tests successful creation of a ResultSetMetadata model."""
+        data = {
+            "numRows": 1,
+            "format": "jsonv2",
+            "rowType": [
+                {
+                    "name": "col1",
+                    "database": "db1",
+                    "schema": "schema1",
+                    "table": "table1",
+                    "type": "text",
+                    "nullable": False,
+                }
+            ],
+            "partitionInfo": [{"rowCount": 1, "uncompressedSize": 10, "compressedSize": 5}],
+        }
+        model = ResultSetMetadata(**data)
+        assert model.num_rows == 1
+        assert len(model.row_type) == 1
+        assert len(model.partition_info) == 1
+
+class TestStatementRequest:
+    """Tests for the StatementRequest model."""
+    def test_statement_request_success(self):
+        """Tests successful creation of a StatementRequest model."""
+        data = {"statement": "SELECT 1", "schema": "my_schema"}
+        model = StatementRequest(**data)
+        assert model.statement == "SELECT 1"
+        assert model.schema_ == "my_schema"
+
+    def test_statement_request_missing_statement(self):
+        """Tests that a ValidationError is raised if 'statement' is missing."""
+        with pytest.raises(ValidationError):
+            StatementRequest(timeout=10)
+
+class TestStatementResponse:
+    """Tests for the StatementResponse model."""
+    def test_statement_response_success(self):
+        """Tests successful creation of a StatementResponse model."""
+        data = {
+            "statementHandle": "1234",
+            "status": "SUCCEEDED",
+            "sqlState": "00000",
+            "dateTime": "2025-09-23T12:00:00Z",
+        }
+        model = StatementResponse(**data)
+        assert model.statement_handle == "1234"
+        assert model.status == StatementStatus.SUCCEEDED
+
+class TestCancellationResponse:
+    """Tests for the CancellationResponse model."""
+    def test_cancellation_response_success(self):
+        """Tests successful creation of a CancellationResponse model."""
+        data = {"status": "CANCELED", "message": "Statement canceled."}
+        model = CancellationResponse(**data)
+        assert model.status == "CANCELED"
+        assert model.message == "Statement canceled."


### PR DESCRIPTION
This commit introduces Pydantic models to create a proxy for the Snowflake SQL REST API as mentioned in #2 

These models define the data structures for requests and responses, ensuring type safety and validation for API interactions.

  ### Key Changes


   - Snowflake API Models 
     (`src/mockhaus/server/snowflake_api/models.py`):
   - Unit Tests 
     (`tests/unit/server/snowflake_api/test_models.py`):
